### PR TITLE
feat: Add 'Open in Safari'

### DIFF
--- a/FollowUI/Sources/FollowUI/EntryDetailView.swift
+++ b/FollowUI/Sources/FollowUI/EntryDetailView.swift
@@ -13,6 +13,7 @@ struct EntryDetailView: View {
     var entry: PostEntries.EntryData
     var onRead: () -> Void
 
+    @Environment(\.openURL) var openURL
     @State private var entryDetail: GetEntries.EntriesData?
 
     var parsedContent: String {
@@ -31,6 +32,13 @@ struct EntryDetailView: View {
         }
         .navigationTitle(entry.entries.title ?? "")
         .toolbarVisibility(.hidden, for: .tabBar)
+        .toolbar(content: {
+            if let urlString = entry.entries.url, let url = URL(string: urlString) {
+                Button("Open in Safari", systemImage: "safari") {
+                    openURL(url)
+                }
+            }
+        })
         .onAppear {
             let service = EntriesService()
 


### PR DESCRIPTION
If we can find a URL from the entry.entries.url within the EntryDetailView, show a safari button, and open the url in safari (or default browser)